### PR TITLE
Add build config for testing the example locally

### DIFF
--- a/java/csv_to_parquet/README.md
+++ b/java/csv_to_parquet/README.md
@@ -11,20 +11,22 @@ Before you begin:
 * Ensure your tenant is configured according to the instructions to [setup admin](https://docs.cloud.oracle.com/en-us/iaas/data-flow/using/dfs_getting_started.htm#set_up_admin)
 * Know your object store namespace.
 * Know the OCID of a compartment where you want to load your data and create applications.
+* (Optional) Set up [OCI CLI](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/cliconcepts.htm) with the necessary privileges to read from and write to the bucket to run the example locally
 * (Optional, strongly recommended): Install Spark to test your code locally before deploying.
 
 ## Instructions
 
 1. Upload a sample CSV file to object store
 2. Customize ```src/main/java/example/Example.java``` with the OCI path to your CSV data. The format is ```oci://<bucket>@<namespace>/path```
-  2a. Don't know what your namespace is? Run ```oci os ns get```
-  2b. Don't have the OCI CLI installed? [See](https://docs.cloud.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm) to install it.
+   - Don't know what your namespace is? Run ```oci os ns get```
+   - Don't have the OCI CLI installed? [See](https://docs.cloud.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm) to install it.
 3. Customize ```src/main/java/example/Example.java``` with the OCI path where you would like to save output data.
 4. Compile with MVN to generate the jar file ```csv_to_parquet-1.0-SNAPSHOT.jar```.
 5. Recommended: run the sample locally to test it.
+   - Uncomment the additional plugin configuration in `pom.xml` to package Example app with all its dependencies
 6. Upload the JAR file ```csv_to_parquet-1.0-SNAPSHOT.jar``` to an object store bucket.
 7. Create a Java Data Flow application pointing to the JAR file ```csv_to_parquet-1.0-SNAPSHOT.jar```
-  7a. Refer [Create Java App](https://docs.oracle.com/en-us/iaas/data-flow/using/dfs_data_flow_library.htm#create_java_app)
+   - Refer [Create Java App](https://docs.oracle.com/en-us/iaas/data-flow/using/dfs_data_flow_library.htm#create_java_app)
 
 ## To Compile
 
@@ -35,7 +37,7 @@ mvn package
 ## To Test Locally
 
 ```sh
-spark-submit --class example.Example target/csv_to_parquet-1.0-SNAPSHOT.jar
+spark-submit --class example.Example target/csv_to_parquet-1.0-SNAPSHOT-jar-with-dependencies.jar
 ```
 
 ## To use OCI CLI to run the Java Application

--- a/java/csv_to_parquet/pom.xml
+++ b/java/csv_to_parquet/pom.xml
@@ -58,6 +58,37 @@
 					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
+
+
+			<!-- Uncomment to Package the Example App with All Its Dependencies: Some dependencies listed
+			above are in the "provided" scope, meaning they will be supplied by OCI at runtime. However,
+			these dependencies are not available when running the application locally. -->
+
+			<!-- <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>3.3.0</version>
+				<configuration>
+					<archive>
+						<manifest>
+							<mainClass>example.Example</mainClass>
+						</manifest>
+					</archive>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+				<executions>
+					<execution>
+						<id>make-assembly</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin> -->
+
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
I'm getting `java.lang.NoClassDefFoundError: com/oracle/bmc/auth/ConfigFileAuthenticationDetailsProvider` with the jar file created by `mvn package`, because a few dependencies are in `provided` scope.

To fix, need to use `maven-assembly-plugin` to bundle the example app jar and its dependencies together.